### PR TITLE
修复自定义鼠标指针主题的绑定目录

### DIFF
--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -255,7 +255,7 @@ try_start() {
         --ro-bind-try "${HOME}/.config/fontconfig"{,}
         --ro-bind-try "${HOME}/.local/share/fonts"{,}
         --ro-bind-try "${HOME}/.icons"{,}
-        --ro-bind-try "${HOME}/.local/share/.icons"{,}
+        --ro-bind-try "${HOME}/.local/share/icons"{,}
 
         # /run
         --dev-bind /run/dbus{,}


### PR DESCRIPTION
绝大多数桌面遵守 [freedesktop 规范](https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html), 将自定义的 icon 放在 `$HOME/.local/share/icons/` 目录而不是 `$HOME/.local/share/.icons/`