### PR TITLE
fix: bus may exist in the `/tmp`, input method is working

### DIFF
--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -185,6 +185,7 @@ try_start() {
 
         # /tmp
         --tmpfs /tmp
+        --ro-bind /tmp{,}
 
         # /opt
         --ro-bind /opt/wechat-universal{,}
@@ -209,7 +210,7 @@ try_start() {
         --dev-bind /run/dbus{,}
         --ro-bind /run/systemd/userdb{,}
         --ro-bind-try "${XAUTHORITY}"{,}
-        --ro-bind "${XDG_RUNTIME_DIR}/bus"{,}
+        --ro-bind-try "${XDG_RUNTIME_DIR}/bus"{,}
         --ro-bind "${XDG_RUNTIME_DIR}/pulse"{,}
     )
 


### PR DESCRIPTION
某些情况下，可能其dbus存在于 `/tmp` 路径下
添加绑定后，我的输入法可正常工作了，fcitx5
