### PR TITLE
Improve the multi-instance implementation

### DIFF
--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -151,9 +151,23 @@ try_start() {
     mkdir -p "${WECHAT_FILES_DIR}" "${WECHAT_HOME_DIR}"
     ln -snf "${WECHAT_FILES_DIR}" "${WECHAT_HOME_DIR}/xwechat_files"
 
-    BWRAP_ARGS=(
-        # Drop privileges
-        --unshare-all
+    BWRAP_ARGS=()
+
+    if [[ -n "${MULTIPLE_INSTANCE}" ]];then
+        BWRAP_ARGS+=(
+            --unshare-user-try
+            --unshare-ipc
+            --unshare-uts 
+            --unshare-cgroup-try
+        )
+    else
+        BWRAP_ARGS+=(
+            # Drop privileges
+            --unshare-all
+        )
+    fi
+
+    BWRAP_ARGS+=(
         --share-net
         --cap-drop ALL
         --die-with-parent

--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -78,10 +78,6 @@ try_start() {
     WECHAT_FILES_DIR="${WECHAT_DATA_DIR}/xwechat_files"
     WECHAT_HOME_DIR="${WECHAT_DATA_DIR}/home"
 
-    if [[ -n "${MULTIPLE_INSTANCE}" ]];then
-        rm -f "${WECHAT_HOME_DIR}/.xwechat/lock/lock.ini"
-    fi
-
     # Runtime folder setup
     XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$(xdg-user-dir RUNTIME)}"
     if [[ -z "${XDG_RUNTIME_DIR}" ]]; then
@@ -224,6 +220,12 @@ try_start() {
         --ro-bind "${DBUS_SESSION_BUS_PATH}"{,}
         --ro-bind "${XDG_RUNTIME_DIR}/pulse"{,}
     )
+
+    if [[ -n "${MULTIPLE_INSTANCE}" ]];then
+        BWRAP_ARGS+=(
+            --tmpfs "${HOME}/.xwechat"
+        )
+    fi
 
     exec bwrap "${BWRAP_ARGS[@]}" "${BWRAP_CUSTOM_BINDS[@]}" "${BWRAP_DEV_BINDS[@]}" /opt/wechat-universal/wechat "$@"
     echo "Error: Failed to exec bwrap, rerun this script with 'bash -x $0' to show the full command history"

--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -227,10 +227,10 @@ try_start() {
                 --tmpfs "${HOME}/.xwechat"
             )
         else
-            _INSTANCE_RUNTIME_DIR="${WECHAT_HOME_DIR}/.xwechat.$(printf '%s' ${MULTIPLE_INSTANCE} |md5sum|awk '{print $1}')"
-            mkdir -p "${_INSTANCE_RUNTIME_DIR}"
+            _INSTANCE_RUNTIME_DIR="${WECHAT_HOME_DIR}/.multi_xwechat_instance/$(printf '%s' ${MULTIPLE_INSTANCE} |md5sum|awk '{print $1}')"
+            mkdir -p "${_INSTANCE_RUNTIME_DIR}/.xwechat"
             BWRAP_ARGS+=(
-                --bind "${_INSTANCE_RUNTIME_DIR}" "${HOME}/.xwechat"
+                --bind "${_INSTANCE_RUNTIME_DIR}/.xwechat" "${HOME}/.xwechat"
             )
         fi
     fi

--- a/wechat-universal.sh
+++ b/wechat-universal.sh
@@ -225,16 +225,19 @@ try_start() {
         if [[ "${MULTIPLE_INSTANCE}" == "auto" ]]; then
             BWRAP_ARGS+=(
                 --tmpfs "${HOME}/.xwechat"
+                --tmpfs "${WECHAT_FILES_DIR}/all_users"
+                --tmpfs "${WECHAT_FILES_DIR}/WMPF"
             )
         else
             _INSTANCE_RUNTIME_DIR="${WECHAT_HOME_DIR}/.multi_xwechat_instance/$(printf '%s' ${MULTIPLE_INSTANCE} |md5sum|awk '{print $1}')"
-            mkdir -p "${_INSTANCE_RUNTIME_DIR}/.xwechat"
+            mkdir -p "${_INSTANCE_RUNTIME_DIR}/"{.xwechat,xwechat_files/all_users/config,xwechat_files/WMPF}
             BWRAP_ARGS+=(
                 --bind "${_INSTANCE_RUNTIME_DIR}/.xwechat" "${HOME}/.xwechat"
+                --bind "${_INSTANCE_RUNTIME_DIR}/xwechat_files/all_users" "${WECHAT_FILES_DIR}/all_users"
+                --bind "${_INSTANCE_RUNTIME_DIR}/xwechat_files/WMPF" "${WECHAT_FILES_DIR}/WMPF"
             )
         fi
     fi
-
     exec bwrap "${BWRAP_ARGS[@]}" "${BWRAP_CUSTOM_BINDS[@]}" "${BWRAP_DEV_BINDS[@]}" /opt/wechat-universal/wechat "$@"
     echo "Error: Failed to exec bwrap, rerun this script with 'bash -x $0' to show the full command history"
     return 1


### PR DESCRIPTION
Temporize the .xwechat directory while sharing .xwechat_files, ensuring better stability while preserving all chat files and chat history.

`.xwechat` 目录因为存储运行时的一些数据 共享运行一段时间后微信会随机退出,时间不固定
使用 `--data` 方案会使得聊天记录和文件分开存放 不方便管理
修改多开的实现方式为:
当使用多开参数`--multiple`后 `.xwechat`为一个临时的目录(或者指定名称的),使得运行数据彻底分开,但是`xwechat_files`的聊天记录和文件依然共享存储(微信存储聊天文件本身是分目录存储的),用户无需再管理多份聊天记录的数据目录,微信的个性化设置也可以正常保存

~已知问题:~
- ~多个微信托盘无法呼出任意一个,所以微信窗口不能点击关闭的方式去隐藏窗口 (同 `--data` 方案)~ 
(已修复,但目前`--data`方案仍然存在此问题,故而当前不推荐使用  `--data`方案实现多开)
- ~多开参数的打开的实例自动登陆失效:原因是,自动登陆是数据存在 `.xwechat` 如果需保留自动登陆,需要给`--multiple` 增加参数给实例命名才能持久化数据,考虑后期再实现~
(已实现)